### PR TITLE
Add 4.08.0+beta1

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+afl/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, with afl-fuzz instrumentation"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-afl" "--disable-debug-runtime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl"
+    "--disable-debug-runtime"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+default-unsafe-string/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, without safe strings by default"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--disable-force-safe-string"
+    "--with-default-string=unsafe"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+flambda/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, with flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-flambda"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp+flambda/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, with frame-pointers and flambda activated"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "--enable-flambda"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1+fp/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0, with frame pointers"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+  ] {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--enable-frame-pointers"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+beta1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "first beta of 4.08.0"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=cc"
+    "ASPP=cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.08.0+beta1.tar.gz"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+trunk+default-unsafe-string/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "latest 4.07 development, without safe strings by default"
+synopsis: "latest 4.08 development, without safe strings by default"
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml" {= "4.08.0" & post}


### PR DESCRIPTION
The first commit fixes the version number in the synopsis field for 4.08.0+trunk+default-unsafe-string.

The second commit adds 4.08.0+beta1 with the following variants.
* 4.08.0+beta1
* 4.08.0+beta1+afl
* 4.08.0+beta1+default_unsafe_string
* 4.08.0+beta1+flambda
* 4.08.0+beta1+fp
* 4.08.0+beta1+fp+flambda

When this is merged, I'll be able to announce beta1 with the one-liner from @altgr (https://github.com/ocaml/opam-repository/pull/13302#issuecomment-460993984).
